### PR TITLE
Docker support for development & testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,26 @@ tests: ## Run tests
 build: ## Build binary
 	go build -ldflags "-s -w" -o zenit main.go
 
-release: ## Create release.
+release: ## Create release
 	scripts/release.sh
+
+docker-build: ## Build docker images
+	docker-compose --file docker/docker-compose.yml build
+
+docker-up: ## Run docker-compose
+	docker-compose --file docker/docker-compose.yml up --detach
+	docker cp assets/schema/clickhouse/zenit.sql docker_clickhouse_1:/root
+	docker exec -i -t -u root docker_clickhouse_1 /bin/bash -c "cat /root/zenit.sql | /usr/bin/clickhouse-client --multiquery"
+
+docker-down: ## Down docker-compose
+	docker-compose --file docker/docker-compose.yml down
+
+docker-clickhouse: ## Enter into ClickHouse Client
+	docker exec -i -t -u root docker_clickhouse_1 /usr/bin/clickhouse-client
+
+docker-zenit-bash: ## Enter into zenit container
+	docker exec -i -t -u root docker_zenit_1 /bin/bash
+
+docker-zenit-build: ## Build binary and copy to container
+	GOOS=linux go build -ldflags "-s -w" -o zenit main.go
+	docker cp zenit docker_zenit_1:/root

--- a/docker/clickhouse/Dockerfile
+++ b/docker/clickhouse/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:18.04
+
+ARG repository="deb http://repo.yandex.ru/clickhouse/deb/stable/ main/"
+ARG version=18.10.3
+
+RUN apt-get update && \
+    apt-get install -y apt-transport-https dirmngr && \
+    mkdir -p /etc/apt/sources.list.d && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv E0C56BD4 && \
+    echo $repository | tee /etc/apt/sources.list.d/clickhouse.list && \
+    apt-get update && \
+    env DEBIAN_FRONTEND=noninteractive apt-get install --allow-unauthenticated -y clickhouse-server=$version clickhouse-common-static=$version libgcc-7-dev && \
+    env DEBIAN_FRONTEND=noninteractive apt-get install --allow-unauthenticated -y clickhouse-client=$version clickhouse-common-static=$version locales tzdata && \
+    rm -rf /var/lib/apt/lists/* /var/cache/debconf && \
+    apt-get clean
+
+COPY config.xml /etc/clickhouse-server/config.d/
+
+RUN chown -R clickhouse /etc/clickhouse-server/
+RUN locale-gen en_US.UTF-8
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+USER clickhouse
+
+EXPOSE 9000 8123 9009
+
+VOLUME /var/lib/clickhouse
+
+ENTRYPOINT exec /usr/bin/clickhouse-server --config=/etc/clickhouse-server/config.xml

--- a/docker/clickhouse/config.xml
+++ b/docker/clickhouse/config.xml
@@ -1,0 +1,12 @@
+<yandex>
+     <!-- Listen wildcard address to allow accepting connections from other containers and host network. -->
+    <listen_host>::</listen_host>
+    <listen_host>0.0.0.0</listen_host>
+    <listen_try>1</listen_try>
+
+    <!--
+    <logger>
+        <console>1</console>
+    </logger>
+    -->
+</yandex>

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,33 @@
+---
+version: '3'
+
+services:
+  clickhouse:
+    image: clickhouse
+    build: clickhouse
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    ports:
+      - "8123:8123"
+    networks:
+      default:
+        ipv4_address: 172.20.1.2
+
+  zenit:
+    image: zenit
+    build:
+      context: ../
+      dockerfile: docker/zenit/Dockerfile
+    networks:
+      default:
+        ipv4_address: 172.20.1.3
+
+networks:
+  default:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.20.1.0/24


### PR DESCRIPTION
- Docker image for clickhouse
- Docker image empty to work with zenit tool inside.